### PR TITLE
feat/column views

### DIFF
--- a/docs/superpowers/plans/2026-05-22-simplified-column-view.md
+++ b/docs/superpowers/plans/2026-05-22-simplified-column-view.md
@@ -1,0 +1,678 @@
+# Simplified Column View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a simplified 13-column kanban view that collapses committee-level granularity into high-level phases, with a toggle to switch between simplified and detailed views.
+
+**Architecture:** Presentation-layer mapping approach. Define `SIMPLIFIED_COLUMNS` and `STATUS_TO_SIMPLIFIED` constants alongside existing `KANBAN_COLUMNS`. The board component selects which column set to use based on a `columnView` state in `KanbanBoardContext`. No database, API, or algorithm changes.
+
+**Tech Stack:** Next.js 15, React, TypeScript, shadcn/ui Switch component, Vitest
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/lib/kanban-columns.ts` | Add `SIMPLIFIED_COLUMNS` array and `STATUS_TO_SIMPLIFIED` mapping |
+| Modify | `src/lib/__tests__/kanban-columns.test.ts` | Tests for new exports |
+| Modify | `src/hooks/contexts/kanban-board-context.tsx` | Add `columnView` / `setColumnView` state |
+| Modify | `src/components/kanban/kanban-header.tsx` | Add Detailed View toggle switch |
+| Modify | `src/components/kanban/kanban-board.tsx` | Use active column set for grouping, scroll, and dnd gating |
+| Modify | `src/components/kanban/protected-kanban-board.tsx` | Set default `columnView` based on auth state |
+
+---
+
+### Task 1: Add SIMPLIFIED_COLUMNS and STATUS_TO_SIMPLIFIED
+
+**Files:**
+- Modify: `src/lib/kanban-columns.ts`
+- Test: `src/lib/__tests__/kanban-columns.test.ts`
+
+- [ ] **Step 1: Write failing tests for SIMPLIFIED_COLUMNS and STATUS_TO_SIMPLIFIED**
+
+Add these tests to the bottom of `src/lib/__tests__/kanban-columns.test.ts`:
+
+```typescript
+import { SIMPLIFIED_COLUMNS, STATUS_TO_SIMPLIFIED } from '../kanban-columns';
+
+describe('SIMPLIFIED_COLUMNS', () => {
+  it('has exactly 13 columns', () => {
+    expect(SIMPLIFIED_COLUMNS.length).toBe(13);
+  });
+
+  it('starts with unassigned and ends with lawWithoutSignature', () => {
+    expect(SIMPLIFIED_COLUMNS[0].id).toBe('unassigned');
+    expect(SIMPLIFIED_COLUMNS[SIMPLIFIED_COLUMNS.length - 1].id).toBe('lawWithoutSignature');
+  });
+
+  it('each column has id and title', () => {
+    for (const col of SIMPLIFIED_COLUMNS) {
+      expect(typeof col.id).toBe('string');
+      expect(col.id.length).toBeGreaterThan(0);
+      expect(typeof col.title).toBe('string');
+      expect(col.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate ids', () => {
+    const ids = SIMPLIFIED_COLUMNS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('contains key phases in order', () => {
+    const ids = SIMPLIFIED_COLUMNS.map((c) => c.id);
+    const waiting = ids.indexOf('simpleWaiting');
+    const scheduled = ids.indexOf('simpleScheduled');
+    const crossoverWaiting = ids.indexOf('simpleCrossoverWaiting');
+    const crossoverScheduled = ids.indexOf('simpleCrossoverScheduled');
+    const conference = ids.indexOf('passedCommittees');
+    const governor = ids.indexOf('transmittedGovernor');
+
+    expect(waiting).toBeGreaterThan(0);
+    expect(scheduled).toBeGreaterThan(waiting);
+    expect(crossoverWaiting).toBeGreaterThan(scheduled);
+    expect(crossoverScheduled).toBeGreaterThan(crossoverWaiting);
+    expect(conference).toBeGreaterThan(crossoverScheduled);
+    expect(governor).toBeGreaterThan(conference);
+  });
+});
+
+describe('STATUS_TO_SIMPLIFIED', () => {
+  it('maps every BillStatus to a valid simplified column', () => {
+    const simplifiedIds = new Set(SIMPLIFIED_COLUMNS.map((c) => c.id));
+    const allStatuses = [
+      'unassigned', 'introduced', 'scheduled1', 'scheduled2', 'scheduled3',
+      'waiting2', 'waiting3', 'deferred1', 'deferred2', 'deferred3',
+      'crossoverWaiting1', 'crossoverWaiting2', 'crossoverWaiting3',
+      'crossoverScheduled1', 'crossoverScheduled2', 'crossoverScheduled3',
+      'crossoverDeferred1', 'crossoverDeferred2', 'crossoverDeferred3',
+      'passedCommittees', 'conferenceAssigned', 'conferenceScheduled',
+      'conferenceDeferred', 'conferencePassed', 'transmittedGovernor',
+      'vetoList', 'governorSigns', 'lawWithoutSignature',
+    ];
+
+    for (const status of allStatuses) {
+      expect(STATUS_TO_SIMPLIFIED[status]).toBeDefined();
+      expect(simplifiedIds.has(STATUS_TO_SIMPLIFIED[status])).toBe(true);
+    }
+  });
+
+  it('maps waiting statuses to simpleWaiting', () => {
+    expect(STATUS_TO_SIMPLIFIED['introduced']).toBe('simpleWaiting');
+    expect(STATUS_TO_SIMPLIFIED['waiting2']).toBe('simpleWaiting');
+    expect(STATUS_TO_SIMPLIFIED['waiting3']).toBe('simpleWaiting');
+  });
+
+  it('maps scheduled and deferred statuses to simpleScheduled', () => {
+    expect(STATUS_TO_SIMPLIFIED['scheduled1']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['scheduled2']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['scheduled3']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred1']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred2']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred3']).toBe('simpleScheduled');
+  });
+
+  it('maps crossover waiting statuses to simpleCrossoverWaiting', () => {
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting1']).toBe('simpleCrossoverWaiting');
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting2']).toBe('simpleCrossoverWaiting');
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting3']).toBe('simpleCrossoverWaiting');
+  });
+
+  it('maps crossover scheduled and deferred statuses to simpleCrossoverScheduled', () => {
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled1']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled2']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled3']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred1']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred2']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred3']).toBe('simpleCrossoverScheduled');
+  });
+
+  it('maps conference and governor statuses to themselves', () => {
+    expect(STATUS_TO_SIMPLIFIED['passedCommittees']).toBe('passedCommittees');
+    expect(STATUS_TO_SIMPLIFIED['conferenceAssigned']).toBe('conferenceAssigned');
+    expect(STATUS_TO_SIMPLIFIED['conferenceScheduled']).toBe('conferenceScheduled');
+    expect(STATUS_TO_SIMPLIFIED['conferenceDeferred']).toBe('conferenceScheduled');
+    expect(STATUS_TO_SIMPLIFIED['conferencePassed']).toBe('conferencePassed');
+    expect(STATUS_TO_SIMPLIFIED['transmittedGovernor']).toBe('transmittedGovernor');
+    expect(STATUS_TO_SIMPLIFIED['vetoList']).toBe('vetoList');
+    expect(STATUS_TO_SIMPLIFIED['governorSigns']).toBe('governorSigns');
+    expect(STATUS_TO_SIMPLIFIED['lawWithoutSignature']).toBe('lawWithoutSignature');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/lib/__tests__/kanban-columns.test.ts`
+Expected: FAIL — `SIMPLIFIED_COLUMNS` and `STATUS_TO_SIMPLIFIED` are not exported from `kanban-columns.ts`
+
+- [ ] **Step 3: Implement SIMPLIFIED_COLUMNS and STATUS_TO_SIMPLIFIED**
+
+Add to the bottom of `src/lib/kanban-columns.ts` (before the closing of the file, after the `COLUMN_INDEX` export):
+
+```typescript
+export const SIMPLIFIED_COLUMNS: KanbanColumnData[] = [
+  { id: 'unassigned', title: 'Not Assigned' },
+  { id: 'simpleWaiting', title: 'INTRODUCED & WAITING' },
+  { id: 'simpleScheduled', title: 'SCHEDULED' },
+  { id: 'simpleCrossoverWaiting', title: 'CROSSOVER & WAITING' },
+  { id: 'simpleCrossoverScheduled', title: 'CROSSOVER SCHEDULED' },
+  { id: 'passedCommittees', title: 'CONFERENCE' },
+  { id: 'conferenceAssigned', title: 'AWAITING COMMITTEES' },
+  { id: 'conferenceScheduled', title: 'SCHEDULED' },
+  { id: 'conferencePassed', title: 'PASSED CONFERENCE' },
+  { id: 'transmittedGovernor', title: 'TRANSMITTED TO GOVERNOR' },
+  { id: 'vetoList', title: 'GOVERNOR VETOED' },
+  { id: 'governorSigns', title: 'GOVERNOR SIGNED INTO LAW' },
+  { id: 'lawWithoutSignature', title: 'LAW WITHOUT SIGNATURE' },
+];
+
+// Maps every BillStatus to the simplified column it belongs to
+export const STATUS_TO_SIMPLIFIED: Record<string, string> = {
+  unassigned: 'unassigned',
+  // Pre-crossover waiting
+  introduced: 'simpleWaiting',
+  waiting2: 'simpleWaiting',
+  waiting3: 'simpleWaiting',
+  // Pre-crossover scheduled (includes deferred)
+  scheduled1: 'simpleScheduled',
+  scheduled2: 'simpleScheduled',
+  scheduled3: 'simpleScheduled',
+  deferred1: 'simpleScheduled',
+  deferred2: 'simpleScheduled',
+  deferred3: 'simpleScheduled',
+  // Crossover waiting
+  crossoverWaiting1: 'simpleCrossoverWaiting',
+  crossoverWaiting2: 'simpleCrossoverWaiting',
+  crossoverWaiting3: 'simpleCrossoverWaiting',
+  // Crossover scheduled (includes deferred)
+  crossoverScheduled1: 'simpleCrossoverScheduled',
+  crossoverScheduled2: 'simpleCrossoverScheduled',
+  crossoverScheduled3: 'simpleCrossoverScheduled',
+  crossoverDeferred1: 'simpleCrossoverScheduled',
+  crossoverDeferred2: 'simpleCrossoverScheduled',
+  crossoverDeferred3: 'simpleCrossoverScheduled',
+  // Conference (1:1)
+  passedCommittees: 'passedCommittees',
+  conferenceAssigned: 'conferenceAssigned',
+  conferenceScheduled: 'conferenceScheduled',
+  conferenceDeferred: 'conferenceScheduled',
+  conferencePassed: 'conferencePassed',
+  // Governor (1:1)
+  transmittedGovernor: 'transmittedGovernor',
+  vetoList: 'vetoList',
+  governorSigns: 'governorSigns',
+  lawWithoutSignature: 'lawWithoutSignature',
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --run src/lib/__tests__/kanban-columns.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/kanban-columns.ts src/lib/__tests__/kanban-columns.test.ts
+git commit -m "feat: add SIMPLIFIED_COLUMNS and STATUS_TO_SIMPLIFIED mapping"
+```
+
+---
+
+### Task 2: Add columnView state to KanbanBoardContext
+
+**Files:**
+- Modify: `src/hooks/contexts/kanban-board-context.tsx`
+
+- [ ] **Step 1: Add columnView state to context type and provider**
+
+In `src/hooks/contexts/kanban-board-context.tsx`, update the interface to add the new fields:
+
+```typescript
+interface KanbanBoardContextType {
+  view: 'kanban' | 'spreadsheet' | 'admin' | 'approvals' | 'supervisor';
+  setView: Dispatch<SetStateAction<'kanban' | 'spreadsheet' | 'admin' | 'approvals' | 'supervisor'>>;
+  columnView: 'detailed' | 'simplified';
+  setColumnView: Dispatch<SetStateAction<'detailed' | 'simplified'>>;
+  searchQuery: string;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
+  selectedTagIds: string[];
+  setSelectedTagIds: Dispatch<SetStateAction<string[]>>;
+  selectedYears: number[];
+  setSelectedYears: Dispatch<SetStateAction<number[]>>;
+}
+```
+
+In the `KanbanBoardProvider` function, add the state:
+
+```typescript
+const [columnView, setColumnView] = useState<'detailed' | 'simplified'>('simplified');
+```
+
+Update the Provider value to include `columnView, setColumnView`:
+
+```typescript
+<KanbanBoardContext.Provider value={{ searchQuery, setSearchQuery, view, setView, columnView, setColumnView, selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears }}>
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS (no type errors — `columnView` and `setColumnView` are now available but not yet consumed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/contexts/kanban-board-context.tsx
+git commit -m "feat: add columnView state to KanbanBoardContext"
+```
+
+---
+
+### Task 3: Add toggle switch to KanbanHeader
+
+**Files:**
+- Modify: `src/components/kanban/kanban-header.tsx`
+
+- [ ] **Step 1: Add the Detailed View toggle to the header**
+
+In `src/components/kanban/kanban-header.tsx`, add `columnView` and `setColumnView` to the destructured context:
+
+Change this line:
+```typescript
+const { selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears } = useKanbanBoard();
+```
+
+To:
+```typescript
+const { columnView, setColumnView, selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears } = useKanbanBoard();
+```
+
+Add the toggle switch. Insert it as a new element inside the right-side `div` (the one with `className='flex items-center space-x-2 mr-4 py-2'`), before the `<TagFilterList>` component:
+
+```tsx
+<div className='flex items-center space-x-2'>
+  <Switch
+    id='column-view'
+    checked={columnView === 'detailed'}
+    onCheckedChange={(checked) => setColumnView(checked ? 'detailed' : 'simplified')}
+  />
+  <Label htmlFor='column-view' className='text-md'>Detailed View</Label>
+</div>
+```
+
+- [ ] **Step 2: Verify the dev server renders correctly**
+
+Run: `npm run dev` (if not already running)
+Open `http://localhost:9002` in a browser. Verify:
+- The "Detailed View" toggle switch appears in the header toolbar
+- Toggling it on/off does not crash the page (the board doesn't change yet — that's Task 5)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/kanban/kanban-header.tsx
+git commit -m "feat: add Detailed View toggle switch to kanban header"
+```
+
+---
+
+### Task 4: Set default columnView based on auth state
+
+**Files:**
+- Modify: `src/components/kanban/protected-kanban-board.tsx`
+
+- [ ] **Step 1: Import setColumnView and set default on mount**
+
+In `src/components/kanban/protected-kanban-board.tsx`, add `useEffect` to the React import:
+
+```typescript
+import React, { useEffect } from 'react';
+```
+
+Update the destructured context to include `setColumnView`:
+
+Change:
+```typescript
+const { view } = useKanbanBoard();
+```
+
+To:
+```typescript
+const { view, setColumnView } = useKanbanBoard();
+```
+
+Add a `useEffect` after the existing hook calls (after the `useTrackedBills` line) to set the default for authenticated tenant members:
+
+```typescript
+useEffect(() => {
+  if (user && activeTenant) {
+    setColumnView('detailed');
+  }
+}, [user, activeTenant, setColumnView]);
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Open `http://localhost:9002`. Verify:
+- As a public user (not logged in): toggle defaults to OFF (simplified)
+- As an authenticated tenant member: toggle defaults to ON (detailed)
+- Both users can still toggle freely
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/kanban/protected-kanban-board.tsx
+git commit -m "feat: default columnView to detailed for authenticated tenant members"
+```
+
+---
+
+### Task 5: Wire up KanbanBoard to use active column set
+
+**Files:**
+- Modify: `src/components/kanban/kanban-board.tsx`
+
+- [ ] **Step 1: Update imports and read columnView from context**
+
+In `src/components/kanban/kanban-board.tsx`, update the import from `kanban-columns.ts`:
+
+Change:
+```typescript
+import { KANBAN_COLUMNS, COLUMN_TITLES } from '@/lib/kanban-columns';
+```
+
+To:
+```typescript
+import { KANBAN_COLUMNS, COLUMN_TITLES, SIMPLIFIED_COLUMNS, STATUS_TO_SIMPLIFIED } from '@/lib/kanban-columns';
+```
+
+Update the destructured context:
+
+Change:
+```typescript
+const { searchQuery, selectedTagIds, selectedYears } = useKanbanBoard();
+```
+
+To:
+```typescript
+const { searchQuery, selectedTagIds, selectedYears, columnView } = useKanbanBoard();
+```
+
+- [ ] **Step 2: Compute active column set and scroll indices**
+
+Replace the static index constants at the top of the file (lines 19-22):
+
+```typescript
+const introducedIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'introduced');
+const crossoverIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'crossoverWaiting1');
+const conferenceIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'conferenceAssigned');
+const governorIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'transmittedGovernor');
+```
+
+Remove these 4 lines (they'll become dynamic inside the component).
+
+Inside the component function body, after the existing hook calls and before the scroll handler section, add:
+
+```typescript
+const activeColumns = columnView === 'simplified' ? SIMPLIFIED_COLUMNS : KANBAN_COLUMNS;
+const isSimplified = columnView === 'simplified';
+
+const introducedIdx = activeColumns.findIndex((col) =>
+  col.id === (isSimplified ? 'simpleWaiting' : 'introduced')
+);
+const crossoverIdx = activeColumns.findIndex((col) =>
+  col.id === (isSimplified ? 'simpleCrossoverWaiting' : 'crossoverWaiting1')
+);
+const conferenceIdx = activeColumns.findIndex((col) =>
+  col.id === 'conferenceAssigned'
+);
+const governorIdx = activeColumns.findIndex((col) =>
+  col.id === 'transmittedGovernor'
+);
+```
+
+- [ ] **Step 3: Update columnRefs to use activeColumns length**
+
+Change:
+```typescript
+const columnRefs = useRef<(HTMLDivElement | null)[]>(
+  new Array(KANBAN_COLUMNS.length).fill(null)
+);
+```
+
+To:
+```typescript
+const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
+```
+
+Then add a line right after to keep it sized correctly (this avoids stale refs when toggling):
+```typescript
+columnRefs.current.length = activeColumns.length;
+```
+
+- [ ] **Step 4: Update billsByColumn memo to use active column set and mapping**
+
+Replace the entire `billsByColumn` useMemo (lines 164-222) with:
+
+```typescript
+const billsByColumn = useMemo(() => {
+  const grouped = Object.fromEntries(
+    activeColumns.map(c => [c.id, [] as Bill[]])
+  ) as Record<string, Bill[]>;
+
+  let items = (searchQuery.trim() && filteredBills) ? filteredBills : bills;
+
+  // Filter by selected tags if any are selected
+  if (selectedTagIds && selectedTagIds.length > 0) {
+    items = items.filter((bill) => {
+      const billTagIds = bill.tags?.map(tag => tag.id) || [];
+      return billTagIds.some(tagId => selectedTagIds.includes(tagId));
+    });
+  }
+
+  // Filter by selected years if any are selected
+  if (selectedYears && selectedYears.length > 0) {
+    items = items.filter((bill) => {
+      const billYear = bill.year;
+      if (billYear === null || billYear === undefined) {
+        return false;
+      }
+      const normalizedBillYear = typeof billYear === 'string' ? parseInt(billYear, 10) : billYear;
+      return selectedYears.includes(normalizedBillYear);
+    });
+  }
+
+  const fallbackId = activeColumns.find(c => c.id === 'unassigned')?.id
+                   ?? activeColumns[0].id;
+
+  // Group bills into columns
+  for (const bill of items) {
+    let key: string;
+    if (isSimplified) {
+      key = STATUS_TO_SIMPLIFIED[bill.current_bill_status] ?? fallbackId;
+    } else {
+      const valid = activeColumns.some(c => c.id === bill.current_bill_status);
+      key = valid ? bill.current_bill_status : fallbackId;
+    }
+    if (grouped[key]) {
+      grouped[key].push(bill);
+    } else {
+      grouped[fallbackId]?.push(bill);
+    }
+  }
+
+  // Sort each column's bills by latest status update date (most recent first)
+  Object.keys(grouped).forEach((status) => {
+    grouped[status].sort((a, b) => {
+      const getLatestUpdateDate = (bill: Bill): number => {
+        if (bill.latest_update && bill.latest_update.date) {
+          const date = new Date(bill.latest_update.date);
+          return date.getTime();
+        }
+        return 0;
+      };
+
+      const dateA = getLatestUpdateDate(a);
+      const dateB = getLatestUpdateDate(b);
+      return dateB - dateA;
+    });
+  });
+
+  return grouped;
+}, [bills, filteredBills, searchQuery, selectedTagIds, selectedYears, activeColumns, isSimplified]);
+```
+
+- [ ] **Step 5: Update tempBillsByColumn memo**
+
+Replace the `tempBillsByColumn` useMemo (lines 229-243) with:
+
+```typescript
+const tempBillsByColumn = useMemo(() => {
+  const grouped: Record<string, TempBill[]> = {};
+  activeColumns.forEach((c) => (grouped[c.id] = []));
+
+  tempBills.forEach((tb) => {
+    if (searchQuery.trim() && !visibleBillIds.has(tb.id)) {
+      return;
+    }
+    let key: string;
+    if (isSimplified) {
+      key = STATUS_TO_SIMPLIFIED[tb.current_status] ?? 'unassigned';
+    } else {
+      key = tb.current_status as string;
+    }
+    grouped[key]?.push(tb);
+  });
+
+  return grouped;
+}, [tempBills, searchQuery, visibleBillIds, activeColumns, isSimplified]);
+```
+
+- [ ] **Step 6: Update search scroll-to-column to use active column set**
+
+In the "Navigate to first search result" useEffect (around line 131), change:
+
+```typescript
+const columnIndex = KANBAN_COLUMNS.findIndex(col => col.id === billStatus);
+```
+
+To:
+
+```typescript
+let columnIndex: number;
+if (isSimplified) {
+  const simplifiedId = STATUS_TO_SIMPLIFIED[billStatus] ?? billStatus;
+  columnIndex = activeColumns.findIndex(col => col.id === simplifiedId);
+} else {
+  columnIndex = activeColumns.findIndex(col => col.id === billStatus);
+}
+```
+
+Add `isSimplified` and `activeColumns` to that useEffect's dependency array:
+```typescript
+}, [filteredBills, searchQuery, scrollToColumnByIndex, isSimplified, activeColumns]);
+```
+
+- [ ] **Step 7: Update handleTempCardClick to use active column set**
+
+In `handleTempCardClick`, change:
+
+```typescript
+const currentStatusColumnIndex = KANBAN_COLUMNS.findIndex(
+  col => col.id === tempBill.proposed_status
+);
+```
+
+To:
+
+```typescript
+let targetId: string;
+if (isSimplified) {
+  targetId = STATUS_TO_SIMPLIFIED[tempBill.proposed_status] ?? tempBill.proposed_status;
+} else {
+  targetId = tempBill.proposed_status;
+}
+const currentStatusColumnIndex = activeColumns.findIndex(
+  col => col.id === targetId
+);
+```
+
+Add `isSimplified` and `activeColumns` to the dependency array:
+```typescript
+}, [scrollToColumnByIndex, isSimplified, activeColumns]);
+```
+
+- [ ] **Step 8: Update render to use activeColumns and gate drag-and-drop on columnView**
+
+The key rendering change: when `isSimplified` is true, always use the read-only rendering path (no `DragDropContext`), regardless of the `readOnly` prop.
+
+Replace the return statement's conditional rendering. The condition that decides read-only vs DnD changes from `{readOnly ? (` to `{(readOnly || isSimplified) ? (`.
+
+Change:
+```typescript
+{readOnly ? (
+```
+
+To:
+```typescript
+{(readOnly || isSimplified) ? (
+```
+
+Then in BOTH the read-only branch and the DnD branch, replace all 3 occurrences of `KANBAN_COLUMNS.map((column, idx)` with `activeColumns.map((column, idx)`.
+
+In the read-only branch (around line 409):
+```typescript
+{activeColumns.map((column, idx) => (
+```
+
+In the DnD branch (around line 458):
+```typescript
+{activeColumns.map((column, idx) => (
+```
+
+Also update the column lookups for `billsByColumn` and `tempBillsByColumn` in both branches. Change all instances of:
+```typescript
+bills={billsByColumn[column.id as BillStatus] || []}
+```
+To:
+```typescript
+bills={billsByColumn[column.id] || []}
+```
+
+And change all instances of:
+```typescript
+pendingTempBills={tempBillsByColumn[column.id as BillStatus] || []}
+```
+To:
+```typescript
+pendingTempBills={tempBillsByColumn[column.id] || []}
+```
+
+- [ ] **Step 9: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 10: Run all tests**
+
+Run: `npm test`
+Expected: All tests PASS
+
+- [ ] **Step 11: Verify in browser**
+
+Open `http://localhost:9002`. Test:
+- **Public user (not logged in):** Sees simplified view (13 columns) by default. Toggle switches to detailed (25 columns). No drag-and-drop in either view.
+- **Authenticated tenant member:** Sees detailed view by default. Toggle switches to simplified. Drag-and-drop works in detailed view, disabled in simplified.
+- **Search:** Typing a bill number scrolls to the correct column in both views.
+- **Tag/year filters:** Work correctly in both views.
+- **Quick-scroll buttons:** Jump to the right column in both views.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/components/kanban/kanban-board.tsx
+git commit -m "feat: wire kanban board to use active column set based on columnView toggle"
+```

--- a/docs/superpowers/specs/2026-05-21-simplified-column-view-design.md
+++ b/docs/superpowers/specs/2026-05-21-simplified-column-view-design.md
@@ -1,0 +1,103 @@
+# Simplified Column View — Design Spec
+
+## Overview
+
+Add a simplified kanban view that collapses the 25 detailed committee-level columns into 13 high-level columns. The simplified view merges all "waiting" statuses (regardless of committee number) into a single WAITING column, all "scheduled" statuses into a single SCHEDULED column, and does the same for crossover-phase statuses. Conference and governor columns remain unchanged.
+
+**Purpose:** Public users and those unfamiliar with the legislative cycle get a cleaner, less overwhelming view. Org power users retain the detailed view for granular status tracking.
+
+## Column Layout
+
+### Simplified Columns (13 total)
+
+| # | Column ID | Display Title | Statuses Grouped |
+|---|-----------|---------------|------------------|
+| 0 | `unassigned` | NOT ASSIGNED | `unassigned` |
+| 1 | `simpleWaiting` | INTRODUCED & WAITING | `introduced`, `waiting2`, `waiting3` |
+| 2 | `simpleScheduled` | SCHEDULED | `scheduled1`, `scheduled2`, `scheduled3`, `deferred1`, `deferred2`, `deferred3` |
+| 3 | `simpleCrossoverWaiting` | CROSSOVER & WAITING | `crossoverWaiting1`, `crossoverWaiting2`, `crossoverWaiting3` |
+| 4 | `simpleCrossoverScheduled` | CROSSOVER SCHEDULED | `crossoverScheduled1`, `crossoverScheduled2`, `crossoverScheduled3`, `crossoverDeferred1`, `crossoverDeferred2`, `crossoverDeferred3` |
+| 5 | `passedCommittees` | CONFERENCE | `passedCommittees` |
+| 6 | `conferenceAssigned` | AWAITING COMMITTEES | `conferenceAssigned` |
+| 7 | `conferenceScheduled` | SCHEDULED | `conferenceScheduled`, `conferenceDeferred` |
+| 8 | `conferencePassed` | PASSED CONFERENCE | `conferencePassed` |
+| 9 | `transmittedGovernor` | TRANSMITTED TO GOVERNOR | `transmittedGovernor` |
+| 10 | `vetoList` | GOVERNOR VETOED | `vetoList` |
+| 11 | `governorSigns` | GOVERNOR SIGNED INTO LAW | `governorSigns` |
+| 12 | `lawWithoutSignature` | LAW WITHOUT SIGNATURE | `lawWithoutSignature` |
+
+### Detailed Columns (existing, unchanged)
+
+The existing 25-column `KANBAN_COLUMNS` array remains as-is.
+
+## State Management
+
+### KanbanBoardContext
+
+Add to the context:
+- `columnView: 'detailed' | 'simplified'` — which column set is active
+- `setColumnView` — setter
+
+**Default:** `'simplified'` in the provider. `ProtectedKanbanBoard` sets it to `'detailed'` via a `useEffect` on mount when the user is an authenticated tenant member. The user can then toggle freely. If the user logs out or has no tenant, the default remains `'simplified'`.
+
+## Column Definitions (`src/lib/kanban-columns.ts`)
+
+### New Exports
+
+- `SIMPLIFIED_COLUMNS: KanbanColumnData[]` — the 13-column array
+- `STATUS_TO_SIMPLIFIED: Record<string, string>` — maps every `BillStatus` to a simplified column ID
+
+### Existing Exports (unchanged)
+
+- `KANBAN_COLUMNS`, `COLUMN_TITLES`, `COLUMN_INDEX` — no changes
+
+## Board Component Changes (`src/components/kanban/kanban-board.tsx`)
+
+- Read `columnView` from `useKanbanBoard()`
+- Select active column set: `columnView === 'simplified' ? SIMPLIFIED_COLUMNS : KANBAN_COLUMNS`
+- `billsByColumn` memo: when simplified, use `STATUS_TO_SIMPLIFIED` to map each bill's `current_bill_status` to the correct simplified column ID before grouping
+- `tempBillsByColumn` memo: same mapping logic
+- Quick-scroll button indices: compute from the active column set
+- Column refs array: sized to the active column set
+- Search scroll-to-column: uses active column set for index lookup
+- **Drag-and-drop disabled when `columnView === 'simplified'`** — always renders the read-only path (no `DragDropContext`), regardless of the `readOnly` prop
+
+The bill's underlying `current_bill_status` is never mutated. Simplified view is purely a presentation-layer grouping.
+
+## Toggle UI (`src/components/kanban/kanban-header.tsx`)
+
+- Add a `Switch` toggle in the toolbar (left side, alongside existing switches)
+- Label: "Detailed View" — off = simplified, on = detailed
+- Visible to all users (public and authenticated)
+- Reads/writes `columnView` / `setColumnView` from `useKanbanBoard()`
+
+## Drag-and-Drop Behavior
+
+- **Simplified view:** Drag-and-drop always disabled, even for authenticated tenant members
+- **Detailed view:** Existing behavior unchanged — workers propose, admins/supervisors commit directly
+- Rationale: Simplified view targets users unfamiliar with the legislative cycle. Detailed view is for org power users who need granular control.
+
+## Tests (`src/lib/__tests__/kanban-columns.test.ts`)
+
+Extend the existing test file:
+
+- **Completeness:** Every `BillStatus` has an entry in `STATUS_TO_SIMPLIFIED` mapping to a valid simplified column ID
+- **Column count:** `SIMPLIFIED_COLUMNS` has exactly 13 entries
+- **Column order:** Entries are in the expected order
+- **Grouping correctness:** `scheduled1`, `scheduled2`, `scheduled3` all map to `simpleScheduled`; similar for waiting and crossover groups
+- **1:1 statuses:** Conference and governor statuses map to themselves
+
+## What's NOT Changing
+
+- No database changes
+- No API changes
+- No changes to the derived-status algorithm (`src/lib/derived-status.ts`)
+- No changes to `BillStatus` type or `src/db/types.ts` — simplified column IDs are display-only
+- No changes to spreadsheet view, admin dashboard, or approvals view
+- No changes to `KanbanColumn` or `KanbanCard` components
+- No changes to drag-and-drop logic itself — just conditionally disabled
+
+## Future Work (out of scope)
+
+- User settings to persist preferred view per user
+- Custom column configurations per organization

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { Bill, BillStatus, TempBill } from '@/types/legislation';
-import { KANBAN_COLUMNS, COLUMN_TITLES } from '@/lib/kanban-columns';
+import { KANBAN_COLUMNS, COLUMN_TITLES, SIMPLIFIED_COLUMNS, STATUS_TO_SIMPLIFIED } from '@/lib/kanban-columns';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import { searchBills } from '@/services/data/legislation';
@@ -16,10 +16,6 @@ import KanbanBoardSkeleton from './skeletons/skeleton-board';
 import { KanbanColumn } from './kanban-column';
 import { useAuth } from '@/hooks/contexts/auth-context';
 
-const introducedIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'introduced');
-const crossoverIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'crossoverWaiting1');
-const conferenceIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'conferenceAssigned');
-const governorIdx = KANBAN_COLUMNS.findIndex((col) => col.id === 'transmittedGovernor');
 
 interface KanbanBoardProps {
   readOnly: boolean;
@@ -28,7 +24,7 @@ interface KanbanBoardProps {
 }
 
 export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: KanbanBoardProps) {
-  const { searchQuery, selectedTagIds, selectedYears } = useKanbanBoard();
+  const { searchQuery, selectedTagIds, selectedYears, columnView } = useKanbanBoard();
   const { toast } = useToast();
   const { user, activeTenant } = useAuth();
 
@@ -51,15 +47,30 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
   const [filteredBills, setFilteredBills] = useState<Bill[] | null>();
   // const [highlightedBillId, //setHighlightedBillId] = useState<string | null>(null);
 
+  const activeColumns = columnView === 'simplified' ? SIMPLIFIED_COLUMNS : KANBAN_COLUMNS;
+  const isSimplified = columnView === 'simplified';
+
+  const introducedIdx = activeColumns.findIndex((col) =>
+    col.id === (isSimplified ? 'simpleWaiting' : 'introduced')
+  );
+  const crossoverIdx = activeColumns.findIndex((col) =>
+    col.id === (isSimplified ? 'simpleCrossoverWaiting' : 'crossoverWaiting1')
+  );
+  const conferenceIdx = activeColumns.findIndex((col) =>
+    col.id === 'conferenceAssigned'
+  );
+  const governorIdx = activeColumns.findIndex((col) =>
+    col.id === 'transmittedGovernor'
+  );
+
   // =======================================================
   // ============= Scroll Handlers =========================
   // =======================================================
   
   // Create refs for all columns dynamically
   const viewportRef = useRef<HTMLDivElement>(null);
-  const columnRefs = useRef<(HTMLDivElement | null)[]>(
-    new Array(KANBAN_COLUMNS.length).fill(null)
-  );
+  const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
+  columnRefs.current.length = activeColumns.length;
 
   // Store refs to all bill cards across all columns
   const billCardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -139,23 +150,29 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
 
     // Find which column this bill is in
     const billStatus = firstBill.current_bill_status as BillStatus;
-    const columnIndex = KANBAN_COLUMNS.findIndex(col => col.id === billStatus);
-    
+    let columnIndex: number;
+    if (isSimplified) {
+      const simplifiedId = STATUS_TO_SIMPLIFIED[billStatus] ?? billStatus;
+      columnIndex = activeColumns.findIndex(col => col.id === simplifiedId);
+    } else {
+      columnIndex = activeColumns.findIndex(col => col.id === billStatus);
+    }
+
     if (columnIndex >= 0) {
       // Scroll to the column containing the first match
       scrollToColumnByIndex(columnIndex);
-      
+
       // Highlight the first matched bill
       //setHighlightedBillId(firstBill.id);
-      
+
       // Clear highlight after 3 seconds
       const highlightTimeout = setTimeout(() => {
         //setHighlightedBillId(null);
       }, 3000);
-      
+
       return () => clearTimeout(highlightTimeout);
     }
-  }, [filteredBills, searchQuery, scrollToColumnByIndex]);
+  }, [filteredBills, searchQuery, scrollToColumnByIndex, isSimplified, activeColumns]);
 
   // =======================================================
   // ==================== Bill Rendering ===================
@@ -163,8 +180,8 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
 
   const billsByColumn = useMemo(() => {
     const grouped = Object.fromEntries(
-      KANBAN_COLUMNS.map(c => [c.id as BillStatus, [] as Bill[]])
-    ) as Record<BillStatus, Bill[]>;
+      activeColumns.map(c => [c.id, [] as Bill[]])
+    ) as Record<string, Bill[]>;
 
     let items = (searchQuery.trim() && filteredBills) ? filteredBills : bills;
 
@@ -183,43 +200,49 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
         if (billYear === null || billYear === undefined) {
           return false;
         }
-        // Convert to number to handle potential string/number mismatches
         const normalizedBillYear = typeof billYear === 'string' ? parseInt(billYear, 10) : billYear;
         return selectedYears.includes(normalizedBillYear);
       });
     }
 
-    const fallbackId = (KANBAN_COLUMNS.find(c => c.id === 'unassigned')?.id
-                     ?? KANBAN_COLUMNS[0].id) as BillStatus;
+    const fallbackId = activeColumns.find(c => c.id === 'unassigned')?.id
+                     ?? activeColumns[0].id;
 
     // Group bills into columns
     for (const bill of items) {
-      const valid = KANBAN_COLUMNS.some(c => c.id === bill.current_bill_status);
-      const key = (valid ? bill.current_bill_status : fallbackId) as BillStatus;
-      grouped[key].push(bill);
+      let key: string;
+      if (isSimplified) {
+        key = STATUS_TO_SIMPLIFIED[bill.current_bill_status] ?? fallbackId;
+      } else {
+        const valid = activeColumns.some(c => c.id === bill.current_bill_status);
+        key = valid ? bill.current_bill_status : fallbackId;
+      }
+      if (grouped[key]) {
+        grouped[key].push(bill);
+      } else {
+        grouped[fallbackId]?.push(bill);
+      }
     }
 
     // Sort each column's bills by latest status update date (most recent first)
     Object.keys(grouped).forEach((status) => {
-      grouped[status as BillStatus].sort((a, b) => {
-        // Get the latest update date from Bill's latest_update field
+      grouped[status].sort((a, b) => {
         const getLatestUpdateDate = (bill: Bill): number => {
           if (bill.latest_update && bill.latest_update.date) {
             const date = new Date(bill.latest_update.date);
             return date.getTime();
           }
-          
-          return 0; // Put bills without dates at the end
+          return 0;
         };
 
         const dateA = getLatestUpdateDate(a);
         const dateB = getLatestUpdateDate(b);
-        return dateB - dateA; // Descending order (newest first)
+        return dateB - dateA;
       });
     });
 
     return grouped;
-  }, [bills, filteredBills, searchQuery, selectedTagIds, selectedYears]);
+  }, [bills, filteredBills, searchQuery, selectedTagIds, selectedYears, activeColumns, isSimplified]);
 
   const billsToGroup: Bill[] = searchQuery.trim() && filteredBills ? filteredBills : bills;
 
@@ -227,20 +250,24 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
   const visibleBillIds = useMemo(() => new Set(billsToGroup.map((b) => b.id)), [billsToGroup]);
 
   const tempBillsByColumn = useMemo(() => {
-    const grouped: { [key in BillStatus]?: TempBill[] } = {};
-    KANBAN_COLUMNS.forEach((c) => (grouped[c.id as BillStatus] = []));
+    const grouped: Record<string, TempBill[]> = {};
+    activeColumns.forEach((c) => (grouped[c.id] = []));
 
     tempBills.forEach((tb) => {
       if (searchQuery.trim() && !visibleBillIds.has(tb.id)) {
         return;
       }
-      // Group by current_status so temp bill appears in the original column
-      const key = tb.current_status as BillStatus;
+      let key: string;
+      if (isSimplified) {
+        key = STATUS_TO_SIMPLIFIED[tb.current_status] ?? 'unassigned';
+      } else {
+        key = tb.current_status as string;
+      }
       grouped[key]?.push(tb);
     });
 
     return grouped;
-  }, [tempBills, searchQuery, visibleBillIds]);
+  }, [tempBills, searchQuery, visibleBillIds, activeColumns, isSimplified]);
 
   // =======================================================
   // ==================== Drag and Drop ====================
@@ -359,8 +386,14 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
   const handleTempCardClick = useCallback(
     (tempBill: TempBill) => {
       // Find the column index where the real bill currently is (current_status)
-      const currentStatusColumnIndex = KANBAN_COLUMNS.findIndex(
-        col => col.id === tempBill.proposed_status
+      let targetId: string;
+      if (isSimplified) {
+        targetId = STATUS_TO_SIMPLIFIED[tempBill.proposed_status] ?? tempBill.proposed_status;
+      } else {
+        targetId = tempBill.proposed_status;
+      }
+      const currentStatusColumnIndex = activeColumns.findIndex(
+        col => col.id === targetId
       );
 
       // First, scroll horizontally to the column where the real bill is
@@ -390,12 +423,12 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
         }
       }, 300); // Wait for horizontal scroll animation
     },
-    [scrollToColumnByIndex]
+    [scrollToColumnByIndex, isSimplified, activeColumns]
   );
 
   return (
     <>
-      {readOnly ? (
+      {(readOnly || isSimplified) ? (
         <ScrollArea className="h-full w-full whitespace-nowrap p-4">
           <ScrollAreaPrimitive.Viewport
             ref={viewportRef}
@@ -406,7 +439,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
               <KanbanBoardSkeleton />
             ) : (
               <div className="flex space-x-4 pb-4">
-                {KANBAN_COLUMNS.map((column, idx) => (
+                {activeColumns.map((column, idx) => (
                   <div
                     key={column.id}
                     ref={(el) => {
@@ -417,7 +450,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
                     <KanbanColumn
                       columnId={column.id as BillStatus}
                       title={column.title}
-                      bills={billsByColumn[column.id as BillStatus] || []}
+                      bills={billsByColumn[column.id] || []}
                       isDraggingOver={false}
                       draggingBillId={null}
                       onCardClick={handleCardClick}
@@ -426,7 +459,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
                       readOnly={true}
                       enableDnd={false}
 
-                      pendingTempBills={tempBillsByColumn[column.id as BillStatus] || []}
+                      pendingTempBills={tempBillsByColumn[column.id] || []}
                       canModerate={activeTenant?.orgRole === 'admin'}
                       onApproveTemp={(billId) => acceptTempChange(billId)}
                       onRejectTemp={(billId) => rejectTempChange(billId)}
@@ -455,7 +488,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
                 <KanbanBoardSkeleton />
               ) : (
                 <div className="flex space-x-4 pb-4">
-                  {KANBAN_COLUMNS.map((column, idx) => (
+                  {activeColumns.map((column, idx) => (
                     <div
                       key={column.id}
                       ref={(el) => {
@@ -470,7 +503,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
                             {...provided.droppableProps}
                             columnId={column.id as BillStatus}
                             title={column.title}
-                            bills={billsByColumn[column.id as BillStatus] || []}
+                            bills={billsByColumn[column.id] || []}
                             isDraggingOver={snapshot.isDraggingOver}
                             draggingBillId={draggingBillId}
                             onCardClick={handleCardClick}
@@ -479,7 +512,7 @@ export function KanbanBoard({ readOnly, onUnadopt, showUnadoptButton = false }: 
                             readOnly={false}
                             enableDnd={true}
                             /* pending proposals */
-                            pendingTempBills={tempBillsByColumn[column.id as BillStatus] || []}
+                            pendingTempBills={tempBillsByColumn[column.id] || []}
                             canModerate={activeTenant?.orgRole === 'admin'}
                             onApproveTemp={(billId) => acceptTempChange(billId)}
                             onRejectTemp={(billId) => rejectTempChange(billId)}

--- a/src/components/kanban/kanban-column.tsx
+++ b/src/components/kanban/kanban-column.tsx
@@ -21,7 +21,11 @@ import { useAuth } from '@/hooks/contexts/auth-context';
 function getColumnPhaseBg(columnId: string): string {
   if (columnId === 'vetoList') return 'bg-[#f8d7d2]';
   if (columnId === 'governorSigns' || columnId === 'lawWithoutSignature') return 'bg-[#d6e8d4]';
-  if (columnId.startsWith('crossoverWaiting1') || columnId.startsWith('conference') || columnId === 'passedCommittees' || columnId === 'conferencePassed' || columnId === 'transmittedGovernor')
+  // Waiting columns (introduced, waiting, crossover waiting) get olive
+  if (columnId === 'introduced' || columnId === 'simpleWaiting' || columnId.startsWith('crossoverWaiting') || columnId === 'simpleCrossoverWaiting')
+    return 'bg-olive-soft';
+  // Passed committees and transmitted to governor get olive
+  if (columnId === 'passedCommittees' || columnId === 'transmittedGovernor')
     return 'bg-olive-soft';
   return 'bg-secondary/50';
 }
@@ -29,7 +33,11 @@ function getColumnPhaseBg(columnId: string): string {
 function getColumnPhaseHeaderBg(columnId: string): string {
   if (columnId === 'vetoList') return 'bg-[#f8d7d2]/95';
   if (columnId === 'governorSigns' || columnId === 'lawWithoutSignature') return 'bg-[#d6e8d4]/95';
-  if (columnId.startsWith('crossoverWaiting1') || columnId.startsWith('conference') || columnId === 'passedCommittees' || columnId === 'conferencePassed' || columnId === 'transmittedGovernor')
+  // Waiting columns (introduced, waiting, crossover waiting) get olive
+  if (columnId === 'introduced' || columnId === 'simpleWaiting' || columnId.startsWith('crossoverWaiting') || columnId === 'simpleCrossoverWaiting')
+    return 'bg-olive-soft/95';
+  // Passed committees and transmitted to governor get olive
+  if (columnId === 'passedCommittees' || columnId === 'transmittedGovernor')
     return 'bg-olive-soft/95';
   return 'bg-secondary/95';
 }

--- a/src/components/kanban/kanban-header.tsx
+++ b/src/components/kanban/kanban-header.tsx
@@ -12,7 +12,7 @@ import { TagFilterList } from '../tags/tag-filter-list';
 export function KanbanHeader() {
   const { user, activeTenant } = useAuth();
   const { viewMode, toggleViewMode, showArchived, toggleShowArchived } = useBills();
-  const { selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears } = useKanbanBoard();
+  const { columnView, setColumnView, selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears } = useKanbanBoard();
 
   const isPublic = !user;
   const canAddRemoveBills = activeTenant?.orgRole === 'admin';
@@ -40,7 +40,16 @@ export function KanbanHeader() {
           )}
         </div>
 
-        <div className='flex items-center space-x-2 mr-4 py-2'>            
+        <div className='flex items-center space-x-2 mr-4 py-2'>
+
+            <div className='flex items-center space-x-2'>
+              <Switch
+                id='column-view'
+                checked={columnView === 'detailed'}
+                onCheckedChange={(checked) => setColumnView(checked ? 'detailed' : 'simplified')}
+              />
+              <Label htmlFor='column-view' className='text-md'>Detailed View</Label>
+            </div>
 
             <TagFilterList
               selectedTagIds={selectedTagIds}

--- a/src/components/kanban/protected-kanban-board.tsx
+++ b/src/components/kanban/protected-kanban-board.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/contexts/auth-context';
 import { KanbanBoard } from './kanban-board';
 import { KanbanSpreadsheet } from './kanban-spreadsheet';
@@ -16,9 +16,11 @@ export function ProtectedKanbanBoardOrSpreadsheet() {
   const { bills, loadingBills, viewMode } = useBills();
   const { untrackBill } = useTrackedBills();
 
+  const hasSetDefault = useRef(false);
   useEffect(() => {
-    if (user && activeTenant) {
+    if (user && activeTenant && !hasSetDefault.current) {
       setColumnView('detailed');
+      hasSetDefault.current = true;
     }
   }, [user, activeTenant, setColumnView]);
 

--- a/src/components/kanban/protected-kanban-board.tsx
+++ b/src/components/kanban/protected-kanban-board.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useAuth } from '@/hooks/contexts/auth-context';
 import { KanbanBoard } from './kanban-board';
 import { KanbanSpreadsheet } from './kanban-spreadsheet';
@@ -12,9 +12,15 @@ import { useKanbanBoard } from '@/hooks/contexts/kanban-board-context';
 
 export function ProtectedKanbanBoardOrSpreadsheet() {
   const { user, loading, activeTenant, isPublicUser } = useAuth();
-  const { view } = useKanbanBoard();
+  const { view, setColumnView } = useKanbanBoard();
   const { bills, loadingBills, viewMode } = useBills();
   const { untrackBill } = useTrackedBills();
+
+  useEffect(() => {
+    if (user && activeTenant) {
+      setColumnView('detailed');
+    }
+  }, [user, activeTenant, setColumnView]);
 
   if (loading) {
     return null

--- a/src/hooks/contexts/kanban-board-context.tsx
+++ b/src/hooks/contexts/kanban-board-context.tsx
@@ -5,6 +5,8 @@ import React, { createContext, useContext, useState, ReactNode, Dispatch, SetSta
 interface KanbanBoardContextType {
   view: 'kanban' | 'spreadsheet' | 'admin' | 'approvals' | 'supervisor';
   setView: Dispatch<SetStateAction<'kanban' | 'spreadsheet' | 'admin' | 'approvals' | 'supervisor'>>;
+  columnView: 'detailed' | 'simplified';
+  setColumnView: Dispatch<SetStateAction<'detailed' | 'simplified'>>;
   searchQuery: string;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   selectedTagIds: string[];
@@ -18,11 +20,12 @@ const KanbanBoardContext = createContext<KanbanBoardContextType | undefined>(und
 export function KanbanBoardProvider({ children }: { children: ReactNode }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [view, setView] = useState<'kanban' | 'spreadsheet' | 'admin' | 'approvals' | 'supervisor'>('kanban');
+  const [columnView, setColumnView] = useState<'detailed' | 'simplified'>('simplified');
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [selectedYears, setSelectedYears] = useState<number[]>([]);
 
   return (
-    <KanbanBoardContext.Provider value={{ searchQuery, setSearchQuery, view, setView, selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears }}>
+    <KanbanBoardContext.Provider value={{ searchQuery, setSearchQuery, view, setView, columnView, setColumnView, selectedTagIds, setSelectedTagIds, selectedYears, setSelectedYears }}>
       {children}
     </KanbanBoardContext.Provider>
   );

--- a/src/lib/__tests__/kanban-columns.test.ts
+++ b/src/lib/__tests__/kanban-columns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { KANBAN_COLUMNS, COLUMN_TITLES, COLUMN_INDEX } from '../kanban-columns';
+import { KANBAN_COLUMNS, COLUMN_TITLES, COLUMN_INDEX, SIMPLIFIED_COLUMNS, STATUS_TO_SIMPLIFIED } from '../kanban-columns';
 
 describe('KANBAN_COLUMNS', () => {
   it('is a non-empty array', () => {
@@ -74,5 +74,110 @@ describe('COLUMN_INDEX', () => {
 
   it('returns undefined for unknown columns', () => {
     expect(COLUMN_INDEX['nonexistent']).toBeUndefined();
+  });
+});
+
+describe('SIMPLIFIED_COLUMNS', () => {
+  it('has exactly 13 columns', () => {
+    expect(SIMPLIFIED_COLUMNS.length).toBe(13);
+  });
+
+  it('starts with unassigned and ends with lawWithoutSignature', () => {
+    expect(SIMPLIFIED_COLUMNS[0].id).toBe('unassigned');
+    expect(SIMPLIFIED_COLUMNS[SIMPLIFIED_COLUMNS.length - 1].id).toBe('lawWithoutSignature');
+  });
+
+  it('each column has id and title', () => {
+    for (const col of SIMPLIFIED_COLUMNS) {
+      expect(typeof col.id).toBe('string');
+      expect(col.id.length).toBeGreaterThan(0);
+      expect(typeof col.title).toBe('string');
+      expect(col.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate ids', () => {
+    const ids = SIMPLIFIED_COLUMNS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('contains key phases in order', () => {
+    const ids = SIMPLIFIED_COLUMNS.map((c) => c.id);
+    const waiting = ids.indexOf('simpleWaiting');
+    const scheduled = ids.indexOf('simpleScheduled');
+    const crossoverWaiting = ids.indexOf('simpleCrossoverWaiting');
+    const crossoverScheduled = ids.indexOf('simpleCrossoverScheduled');
+    const conference = ids.indexOf('passedCommittees');
+    const governor = ids.indexOf('transmittedGovernor');
+
+    expect(waiting).toBeGreaterThan(0);
+    expect(scheduled).toBeGreaterThan(waiting);
+    expect(crossoverWaiting).toBeGreaterThan(scheduled);
+    expect(crossoverScheduled).toBeGreaterThan(crossoverWaiting);
+    expect(conference).toBeGreaterThan(crossoverScheduled);
+    expect(governor).toBeGreaterThan(conference);
+  });
+});
+
+describe('STATUS_TO_SIMPLIFIED', () => {
+  it('maps every BillStatus to a valid simplified column', () => {
+    const simplifiedIds = new Set(SIMPLIFIED_COLUMNS.map((c) => c.id));
+    const allStatuses = [
+      'unassigned', 'introduced', 'scheduled1', 'scheduled2', 'scheduled3',
+      'waiting2', 'waiting3', 'deferred1', 'deferred2', 'deferred3',
+      'crossoverWaiting1', 'crossoverWaiting2', 'crossoverWaiting3',
+      'crossoverScheduled1', 'crossoverScheduled2', 'crossoverScheduled3',
+      'crossoverDeferred1', 'crossoverDeferred2', 'crossoverDeferred3',
+      'passedCommittees', 'conferenceAssigned', 'conferenceScheduled',
+      'conferenceDeferred', 'conferencePassed', 'transmittedGovernor',
+      'vetoList', 'governorSigns', 'lawWithoutSignature',
+    ];
+
+    for (const status of allStatuses) {
+      expect(STATUS_TO_SIMPLIFIED[status]).toBeDefined();
+      expect(simplifiedIds.has(STATUS_TO_SIMPLIFIED[status])).toBe(true);
+    }
+  });
+
+  it('maps waiting statuses to simpleWaiting', () => {
+    expect(STATUS_TO_SIMPLIFIED['introduced']).toBe('simpleWaiting');
+    expect(STATUS_TO_SIMPLIFIED['waiting2']).toBe('simpleWaiting');
+    expect(STATUS_TO_SIMPLIFIED['waiting3']).toBe('simpleWaiting');
+  });
+
+  it('maps scheduled and deferred statuses to simpleScheduled', () => {
+    expect(STATUS_TO_SIMPLIFIED['scheduled1']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['scheduled2']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['scheduled3']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred1']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred2']).toBe('simpleScheduled');
+    expect(STATUS_TO_SIMPLIFIED['deferred3']).toBe('simpleScheduled');
+  });
+
+  it('maps crossover waiting statuses to simpleCrossoverWaiting', () => {
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting1']).toBe('simpleCrossoverWaiting');
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting2']).toBe('simpleCrossoverWaiting');
+    expect(STATUS_TO_SIMPLIFIED['crossoverWaiting3']).toBe('simpleCrossoverWaiting');
+  });
+
+  it('maps crossover scheduled and deferred statuses to simpleCrossoverScheduled', () => {
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled1']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled2']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverScheduled3']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred1']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred2']).toBe('simpleCrossoverScheduled');
+    expect(STATUS_TO_SIMPLIFIED['crossoverDeferred3']).toBe('simpleCrossoverScheduled');
+  });
+
+  it('maps conference and governor statuses to themselves', () => {
+    expect(STATUS_TO_SIMPLIFIED['passedCommittees']).toBe('passedCommittees');
+    expect(STATUS_TO_SIMPLIFIED['conferenceAssigned']).toBe('conferenceAssigned');
+    expect(STATUS_TO_SIMPLIFIED['conferenceScheduled']).toBe('conferenceScheduled');
+    expect(STATUS_TO_SIMPLIFIED['conferenceDeferred']).toBe('conferenceScheduled');
+    expect(STATUS_TO_SIMPLIFIED['conferencePassed']).toBe('conferencePassed');
+    expect(STATUS_TO_SIMPLIFIED['transmittedGovernor']).toBe('transmittedGovernor');
+    expect(STATUS_TO_SIMPLIFIED['vetoList']).toBe('vetoList');
+    expect(STATUS_TO_SIMPLIFIED['governorSigns']).toBe('governorSigns');
+    expect(STATUS_TO_SIMPLIFIED['lawWithoutSignature']).toBe('lawWithoutSignature');
   });
 });

--- a/src/lib/kanban-columns.ts
+++ b/src/lib/kanban-columns.ts
@@ -59,3 +59,57 @@ export const COLUMN_INDEX: Record<string, number> = KANBAN_COLUMNS.reduce((acc, 
   acc[col.id] = idx;
   return acc;
 }, {} as Record<string, number>);
+
+export const SIMPLIFIED_COLUMNS: KanbanColumnData[] = [
+  { id: 'unassigned', title: 'Not Assigned' },
+  { id: 'simpleWaiting', title: 'INTRODUCED & WAITING' },
+  { id: 'simpleScheduled', title: 'SCHEDULED' },
+  { id: 'simpleCrossoverWaiting', title: 'CROSSOVER & WAITING' },
+  { id: 'simpleCrossoverScheduled', title: 'CROSSOVER SCHEDULED' },
+  { id: 'passedCommittees', title: 'CONFERENCE' },
+  { id: 'conferenceAssigned', title: 'AWAITING COMMITTEES' },
+  { id: 'conferenceScheduled', title: 'SCHEDULED' },
+  { id: 'conferencePassed', title: 'PASSED CONFERENCE' },
+  { id: 'transmittedGovernor', title: 'TRANSMITTED TO GOVERNOR' },
+  { id: 'vetoList', title: 'GOVERNOR VETOED' },
+  { id: 'governorSigns', title: 'GOVERNOR SIGNED INTO LAW' },
+  { id: 'lawWithoutSignature', title: 'LAW WITHOUT SIGNATURE' },
+];
+
+// Maps every BillStatus to the simplified column it belongs to
+export const STATUS_TO_SIMPLIFIED: Record<string, string> = {
+  unassigned: 'unassigned',
+  // Pre-crossover waiting
+  introduced: 'simpleWaiting',
+  waiting2: 'simpleWaiting',
+  waiting3: 'simpleWaiting',
+  // Pre-crossover scheduled (includes deferred)
+  scheduled1: 'simpleScheduled',
+  scheduled2: 'simpleScheduled',
+  scheduled3: 'simpleScheduled',
+  deferred1: 'simpleScheduled',
+  deferred2: 'simpleScheduled',
+  deferred3: 'simpleScheduled',
+  // Crossover waiting
+  crossoverWaiting1: 'simpleCrossoverWaiting',
+  crossoverWaiting2: 'simpleCrossoverWaiting',
+  crossoverWaiting3: 'simpleCrossoverWaiting',
+  // Crossover scheduled (includes deferred)
+  crossoverScheduled1: 'simpleCrossoverScheduled',
+  crossoverScheduled2: 'simpleCrossoverScheduled',
+  crossoverScheduled3: 'simpleCrossoverScheduled',
+  crossoverDeferred1: 'simpleCrossoverScheduled',
+  crossoverDeferred2: 'simpleCrossoverScheduled',
+  crossoverDeferred3: 'simpleCrossoverScheduled',
+  // Conference (1:1)
+  passedCommittees: 'passedCommittees',
+  conferenceAssigned: 'conferenceAssigned',
+  conferenceScheduled: 'conferenceScheduled',
+  conferenceDeferred: 'conferenceScheduled',
+  conferencePassed: 'conferencePassed',
+  // Governor (1:1)
+  transmittedGovernor: 'transmittedGovernor',
+  vetoList: 'vetoList',
+  governorSigns: 'governorSigns',
+  lawWithoutSignature: 'lawWithoutSignature',
+};


### PR DESCRIPTION
- **docs: add simplified column view design spec**
- **docs: add simplified column view implementation plan**
- **feat: add SIMPLIFIED_COLUMNS and STATUS_TO_SIMPLIFIED mapping**
- **feat: add columnView state to KanbanBoardContext**
- **feat: add Detailed View toggle switch to kanban header**
- **feat: default columnView to detailed for authenticated tenant members**
- **feat: wire kanban board to use active column set based on columnView toggle**
- **feat: update column phase backgrounds for simplified view**
